### PR TITLE
Tag-based dynamic versioning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           repository: diffpy/diffpy.utils
           path: .
+          fetch-depth: 0  # avoid shallow clone with no tags
 
       - name: initialize miniconda
         # this uses a marketplace action that sets up miniconda in a way that makes

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ If you prefer to install from sources, after installing the dependencies, obtain
 `GitHub <https://github.com/diffpy/diffpy.utils/>`_. Once installed, ``cd`` into your ``diffpy.utils`` directory
 and run the following ::
 
-   pip install -e .
+   pip install .
 
 To check the installation integrity, if the following passes all checks, you are good! ::
 
@@ -75,9 +75,12 @@ https://github.com/diffpy/diffpy.utils.
 
 Feel free to fork the project and contribute.  To install diffpy.utils
 in a development mode, with its sources being directly used by Python
-rather than copied to a package directory, use ::
+rather than copied to a package directory, use the following in the root
+directory ::
 
-   python setup.py develop --user
+   pip install -e .
+
+Note that this is only supported for `setuptools` version 62.0 and above.
 
 
 CONTACTS

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -63,8 +63,8 @@ copyright = '%Y, Brookhaven National Laboratory'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-from setup import versiondata
-fullversion = versiondata.get('DEFAULT', 'version')
+from importlib.metadata import version
+fullversion = version(project)
 # The short X.Y version.
 version = ''.join(fullversion.split('.post')[:1])
 # The full version, including alpha/beta/rc tags.
@@ -77,8 +77,7 @@ release = fullversion
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
 #today = ''
-today_seconds = versiondata.getint('DEFAULT', 'timestamp')
-today = time.strftime('%B %d, %Y', time.localtime(today_seconds))
+today = time.strftime('%B %d, %Y', time.localtime())
 year = today.split()[-1]
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=62.0"]
+requires = ["setuptools>=62.0", "setuptools-git-versioning<2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "diffpy.utils"
-version = "3.2.7"
+dynamic=['version']
 authors = [
   { name="Simon J.L. Billinge group", email="simon.billinge@gmail.com" },
 ]
@@ -14,7 +14,7 @@ maintainers = [
 description = "Shared utilities for diffpy packages."
 keywords = ["text data parsers", "wx grid", "diffraction objects"]
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -26,7 +26,6 @@ classifiers = [
         'Operating System :: POSIX',
         'Operating System :: Unix',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -37,6 +36,12 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/diffpy/diffpy.utils/"
 Issues = "https://github.com/diffpy/diffpy.utils/issues"
+
+[tool.setuptools-git-versioning]
+enabled = true
+template = "{tag}"
+dev_template = "{tag}.post{ccount}"
+dirty_template = "{tag}.post{ccount}"
 
 [tool.setuptools.packages.find]
 where = ["src"]  # list of folders that contain the packages (["."] by default)

--- a/src/diffpy/utils/version.py
+++ b/src/diffpy/utils/version.py
@@ -36,7 +36,7 @@ if __package__ is not None:
     with as_file(ref) as fcfg:
         if not os.path.isfile(fcfg):    # pragma: no cover
             from warnings import warn
-            warn('Package metadata not found, execute "./setup.py egg_info".')
+            warn('Package metadata not found.')
             fcfg = os.devnull
         with open(fcfg) as fp:
             kwords = [[w.strip() for w in line.split(' = ', 1)]


### PR DESCRIPTION
Removed support for 3.8 (`importlib` not available).
Updated readme instructions.
Simple tag-based dynamic versioning (same as old `setup.py` versioning process).