### PR TITLE
Fix version

### DIFF
--- a/doc/manual/source/utilities/toolsutility.rst
+++ b/doc/manual/source/utilities/toolsutility.rst
@@ -7,17 +7,17 @@ Tools Utility
 
 The ``diffpy.utils.tools`` module provides tool functions for use with diffpy apps.
 
-1) ``get_uder_info``: This function is designed for managing and tracking username and email information.
+1. ``get_user_info``: This function is designed for managing and tracking username and email information.
 
-Developers can use this function to simplify the process of loading, merging, and saving information consistently and easily.
-Additionally, it saves the effort of re-entering information, and allows overriding current information by
-passing parameters.
+   Developers can use this function to simplify the process of loading, merging, and saving information consistently and easily.
+   Additionally, it saves the effort of re-entering information, and allows overriding current information by
+   passing parameters.
 
-2) ``get_package_info``: This function loads package name and version information into a dictionary.
-It updates the package information under the key "package_info" in the format {"package_name": "version_number"},
-resulting in an entry in the passed metadata dictionary that looks like
-`{"package_info": {"package1": "version_number1", "package2": "version_number2"} if the function is called more than
-once.
+2. ``get_package_info``: This function loads package name and version information into a dictionary.
+   It updates the package information under the key "package_info" in the format {"package_name": "version_number"},
+   resulting in an entry in the passed metadata dictionary that looks like
+   ``{"package_info": {"package1": "version_number1", "package2": "version_number2"}`` if the function is called more than
+   once.
 
-Users can use these functions to track and manage versions of packages that can later be stored, for example, in an output 
-file header. 
+   Users can use these functions to track and manage versions of packages that can later be stored, for example, in an output 
+   file header. 

--- a/doc/manual/source/utilities/toolsutility.rst
+++ b/doc/manual/source/utilities/toolsutility.rst
@@ -7,13 +7,13 @@ Tools Utility
 
 The ``diffpy.utils.tools`` module provides tool functions for use with diffpy apps.
 
-1. ``get_user_info``: This function is designed for managing and tracking username and email information.
+1) ``get_user_info``: This function is designed for managing and tracking username and email information.
 
    Developers can use this function to simplify the process of loading, merging, and saving information consistently and easily.
    Additionally, it saves the effort of re-entering information, and allows overriding current information by
    passing parameters.
 
-2. ``get_package_info``: This function loads package name and version information into a dictionary.
+2) ``get_package_info``: This function loads package name and version information into a dictionary.
    It updates the package information under the key "package_info" in the format {"package_name": "version_number"},
    resulting in an entry in the passed metadata dictionary that looks like
    ``{"package_info": {"package1": "version_number1", "package2": "version_number2"}`` if the function is called more than

--- a/src/diffpy/utils/version.py
+++ b/src/diffpy/utils/version.py
@@ -13,46 +13,13 @@
 #
 ##############################################################################
 
-"""
-Definition of __version__, __date__, __timestamp__, __git_commit__.
+"""Definition of __version__."""
 
-Notes
------
-Variable `__gitsha__` is deprecated as of version 3.0.
-Use `__git_commit__` instead.
-"""
+# We do not use the other three variables, but can be added back if needed.
+# __all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
 
-__all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
-
-import os.path
-from importlib.resources import as_file, files
-
-# obtain version information from the version.cfg file
-cp = dict(version="", date="", commit="", timestamp="0")
-if __package__ is not None:
-    ref = files(__package__) / "version.cfg"
-    with as_file(ref) as fcfg:
-        if not os.path.isfile(fcfg):  # pragma: no cover
-            from warnings import warn
-
-            warn("Package metadata not found.")
-            fcfg = os.devnull
-        with open(fcfg) as fp:
-            kwords = [
-                [w.strip() for w in line.split(" = ", 1)] for line in fp if line[:1].isalpha() and " = " in line
-            ]
-        assert all(w[0] in cp for w in kwords), "received unrecognized keyword"
-        cp.update(kwords)
-    del kwords
-
-__version__ = cp["version"]
-__date__ = cp["date"]
-__git_commit__ = cp["commit"]
-__timestamp__ = int(cp["timestamp"])
-
-# TODO remove deprecated __gitsha__ in version 3.1.
-__gitsha__ = __git_commit__
-
-del cp
+# obtain version information
+from importlib.metadata import version
+__version__ = version("diffpy.utils")
 
 # End of file

--- a/src/diffpy/utils/version.py
+++ b/src/diffpy/utils/version.py
@@ -20,6 +20,7 @@
 
 # obtain version information
 from importlib.metadata import version
+
 __version__ = version("diffpy.utils")
 
 # End of file

--- a/src/diffpy/utils/version.py
+++ b/src/diffpy/utils/version.py
@@ -15,8 +15,8 @@
 
 """Definition of __version__."""
 
-# We do not use the other three variables, but can be added back if needed.
-# __all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
+#  We do not use the other three variables, but can be added back if needed.
+#  __all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
 
 # obtain version information
 from importlib.metadata import version


### PR DESCRIPTION
Since we no longer use `setup.py`, we cannot run `egg_info`:
```
/home/sparkypenguin/.local/lib/python3.10/site-packages/diffpy/utils/version.py:39: UserWarning: Package metadata not found, execute "./setup.py egg_info".
  warn('Package metadata not found, execute "./setup.py egg_info".')
```

This warning keeps arising when running items using utils. This PR fixes this issue by removing most of the (unused) `version.py` code as it takes the information from the generated `version.cfg` file.

Also some formatting fixes to `toolsutility.rst` (can be made into a separate PR if requested).