### PR TITLE
Remove `labpdfproc` subdirectory from git ignore

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,6 @@ exclude =
     build,
     dist,
     versioneer.py,
-    labpdfproc/_version.py,
     doc/manual/source/conf.py
 max-line-length = 115
 # Ignore some style 'errors' produced while formatting by 'black' (see link below)


### PR DESCRIPTION
Maybe a residue from testing? Either way, does not seem like it should be here.