### PR TITLE
add secrets inherit

### DIFF
--- a/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
@@ -17,3 +17,4 @@ jobs:
       project: diffpy.utils
       c_extension: false
       headless: false
+    secrets: inherit


### PR DESCRIPTION
hopefully closes #106 

Something worth notice is that {{ secrets.GITHUB_TOKEN }} works differently than other secrets (e.g. {{ secrets.CODECOV_TOKEN }} such that GitHub_token doesn't need any extra configuration and is available for every workflow when it runs, while other secrets are needed to be passed to the reusable workflows.