### PR TITLE
Add pytest-cov test.txt dependency list

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,5 @@ codecov
 coverage
 pytest-env
 pytest-mock
+pytest-cov
 freezegun


### PR DESCRIPTION
We shall use pytest-cov instead of using coverage to run pytest. The previous codecov 0% error occurred because the tests folder has been moved to the top directory level and coverage isn't able to import diffpy.<package-name> due to the namespace.

So the GH actions can be modified 

from:

```
        run: |
          coverage run -m pytest -vv -s
          coverage report -m
          codecov
```

to:

```
        run: |
          pytest --cov
          coverage report -m
          codecov
```

Reference:
- https://github.com/diffpy/diffpy.snmf/pull/86