### PR TITLE
Update setuptools-git-versioning >= 2.0

### DIFF
--- a/news/git-version.rst
+++ b/news/git-version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* setuptools-git-versioning from <2.0 to >= 2.0 in pyproject.toml
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=62.0", "setuptools-git-versioning<2"]
+requires = ["setuptools>=62.0", "setuptools-git-versioning>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Since `diffpy.utils`, is already cookiecuttered, manually fix this versioning.

Reference:
- https://github.com/Billingegroup/cookiecutter/pull/154

