### PR TITLE
Use pytest for `test_loaddata.py`

### DIFF
--- a/news/test-refactor.rst
+++ b/news/test-refactor.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Unittest to Pytest migration for test_loaddata.py
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/parsers/loaddata.py
+++ b/src/diffpy/utils/parsers/loaddata.py
@@ -13,6 +13,8 @@
 #
 ##############################################################################
 
+import os
+
 import numpy
 
 
@@ -98,6 +100,10 @@ def loadData(filename, minrows=10, headers=False, hdel="=", hignore=None, **kwar
         except (IndexError, ValueError):
             nc = nv = 0
         return nc, nv
+
+    # Check if file exists before trying to open
+    if not os.path.exists(filename):
+        raise IOError(f"File {filename} cannot be found. Please rerun the program specifying a valid filename.")
 
     # make sure fid gets cleaned up
     with open(filename, "rb") as fid:

--- a/tests/diffpy/utils/parsers/test_loaddata.py
+++ b/tests/diffpy/utils/parsers/test_loaddata.py
@@ -14,8 +14,9 @@ def test_loadData_default(datafile):
     loaddata01 = datafile("loaddata01.txt")
     d2c = np.array([[3, 31], [4, 32], [5, 33]])
 
-    with pytest.raises(IOError):
+    with pytest.raises(IOError) as err:
         loadData("doesnotexist")
+    assert "No such file or directory" in str(err.value)
 
     # The default minrows=10 makes it read from the third line
     d = loadData(loaddata01)
@@ -51,22 +52,27 @@ def test_loadData_1column(datafile):
 
 def test_loadData_headers(datafile):
     """check loadData() with headers options enabled"""
+    expected = {
+        "wavelength": 0.1,
+        "dataformat": "Qnm",
+        "inputfile": "darkSub_rh20_C_01.chi",
+        "mode": "xray",
+        "bgscale": 1.2998929285,
+        "composition": "0.800.20",
+        "outputtype": "gr",
+        "qmaxinst": 25.0,
+        "qmin": 0.1,
+        "qmax": 25.0,
+        "rmax": "100.0r",
+        "rmin": "0.0r",
+        "rstep": "0.01r",
+        "rpoly": "0.9r",
+    }
+
     loaddatawithheaders = datafile("loaddatawithheaders.txt")
     hignore = ["# ", "// ", "["]  # ignore lines beginning with these strings
     delimiter = ": "  # what our data should be separated by
 
     # Load data with headers
     hdata = loadData(loaddatawithheaders, headers=True, hdel=delimiter, hignore=hignore)
-
-    # Only fourteen lines of data are formatted properly
-    assert len(hdata) == 14
-
-    # Check the following are floats
-    vfloats = ["wavelength", "qmaxinst", "qmin", "qmax", "bgscale"]
-    for name in vfloats:
-        assert isinstance(hdata.get(name), float)
-
-    # Check the following are NOT floats
-    vnfloats = ["composition", "rmax", "rmin", "rstep", "rpoly"]
-    for name in vnfloats:
-        assert not isinstance(hdata.get(name), float)
+    assert hdata == expected

--- a/tests/diffpy/utils/parsers/test_loaddata.py
+++ b/tests/diffpy/utils/parsers/test_loaddata.py
@@ -48,8 +48,6 @@ def test_loadData_1column(datafile):
     d = loadData(loaddata01, usecols=[0], minrows=3)
     assert not np.array_equal(d1c, d)
 
-    return
-
 
 def test_loadData_headers(datafile):
     """check loadData() with headers options enabled"""
@@ -60,7 +58,6 @@ def test_loadData_headers(datafile):
     # Load data with headers
     hdata = loadData(loaddatawithheaders, headers=True, hdel=delimiter, hignore=hignore)
 
-    # Assertions using pytest
     # Only fourteen lines of data are formatted properly
     assert len(hdata) == 14
 

--- a/tests/diffpy/utils/parsers/test_loaddata.py
+++ b/tests/diffpy/utils/parsers/test_loaddata.py
@@ -3,71 +3,73 @@
 """Unit tests for diffpy.utils.parsers.loaddata
 """
 
-import unittest
-
-import numpy
+import numpy as np
 import pytest
 
 from diffpy.utils.parsers.loaddata import loadData
 
 
-##############################################################################
-class TestLoadData(unittest.TestCase):
-    @pytest.fixture(autouse=True)
-    def prepare_fixture(self, datafile):
-        self.datafile = datafile
+def test_loadData_default(datafile):
+    """check loadData() with default options"""
+    loaddata01 = datafile("loaddata01.txt")
+    d2c = np.array([[3, 31], [4, 32], [5, 33]])
 
-    def test_loadData_default(self):
-        """check loadData() with default options"""
-        loaddata01 = self.datafile("loaddata01.txt")
-        d2c = numpy.array([[3, 31], [4, 32], [5, 33]])
-        self.assertRaises(IOError, loadData, "doesnotexist")
-        # the default minrows=10 makes it read from the third line
-        d = loadData(loaddata01)
-        self.assertTrue(numpy.array_equal(d2c, d))
-        # the usecols=(0, 1) would make it read from the third line
-        d = loadData(loaddata01, minrows=1, usecols=(0, 1))
-        self.assertTrue(numpy.array_equal(d2c, d))
-        # check the effect of usecols effect
-        d = loadData(loaddata01, usecols=(0,))
-        self.assertTrue(numpy.array_equal(d2c[:, 0], d))
-        d = loadData(loaddata01, usecols=(1,))
-        self.assertTrue(numpy.array_equal(d2c[:, 1], d))
-        return
+    with pytest.raises(IOError):
+        loadData("doesnotexist")
 
-    def test_loadData_1column(self):
-        """check loading of one-column data."""
-        loaddata01 = self.datafile("loaddata01.txt")
-        d1c = numpy.arange(1, 6)
-        d = loadData(loaddata01, usecols=[0], minrows=1)
-        self.assertTrue(numpy.array_equal(d1c, d))
-        d = loadData(loaddata01, usecols=[0], minrows=2)
-        self.assertTrue(numpy.array_equal(d1c, d))
-        d = loadData(loaddata01, usecols=[0], minrows=3)
-        self.assertFalse(numpy.array_equal(d1c, d))
-        return
+    # The default minrows=10 makes it read from the third line
+    d = loadData(loaddata01)
+    assert np.array_equal(d2c, d)
 
-    def test_loadData_headers(self):
-        """check loadData() with headers options enabled"""
-        loaddatawithheaders = self.datafile("loaddatawithheaders.txt")
-        hignore = ["# ", "// ", "["]  # ignore lines beginning with these strings
-        delimiter = ": "  # what our data should be separated by
-        hdata = loadData(loaddatawithheaders, headers=True, hdel=delimiter, hignore=hignore)
-        # only fourteen lines of data are formatted properly
-        assert len(hdata) == 14
-        # check the following are floats
-        vfloats = ["wavelength", "qmaxinst", "qmin", "qmax", "bgscale"]
-        for name in vfloats:
-            assert isinstance(hdata.get(name), float)
-        # check the following are NOT floats
-        vnfloats = ["composition", "rmax", "rmin", "rstep", "rpoly"]
-        for name in vnfloats:
-            assert not isinstance(hdata.get(name), float)
+    # The usecols=(0, 1) would make it read from the third line
+    d = loadData(loaddata01, minrows=1, usecols=(0, 1))
+    assert np.array_equal(d2c, d)
+
+    # Check the effect of usecols effect
+    d = loadData(loaddata01, usecols=(0,))
+    assert np.array_equal(d2c[:, 0], d)
+
+    d = loadData(loaddata01, usecols=(1,))
+    assert np.array_equal(d2c[:, 1], d)
 
 
-# End of class TestRoutines
+def test_loadData_1column(datafile):
+    """check loading of one-column data."""
+    loaddata01 = datafile("loaddata01.txt")
+    d1c = np.arange(1, 6)
 
-if __name__ == "__main__":
-    unittest.main()
+    # Assertions using pytest's assert
+    d = loadData(loaddata01, usecols=[0], minrows=1)
+    assert np.array_equal(d1c, d)
 
-# End of file
+    d = loadData(loaddata01, usecols=[0], minrows=2)
+    assert np.array_equal(d1c, d)
+
+    d = loadData(loaddata01, usecols=[0], minrows=3)
+    assert not np.array_equal(d1c, d)
+
+    return
+
+
+def test_loadData_headers(datafile):
+    """check loadData() with headers options enabled"""
+    loaddatawithheaders = datafile("loaddatawithheaders.txt")
+    hignore = ["# ", "// ", "["]  # ignore lines beginning with these strings
+    delimiter = ": "  # what our data should be separated by
+
+    # Load data with headers
+    hdata = loadData(loaddatawithheaders, headers=True, hdel=delimiter, hignore=hignore)
+
+    # Assertions using pytest
+    # Only fourteen lines of data are formatted properly
+    assert len(hdata) == 14
+
+    # Check the following are floats
+    vfloats = ["wavelength", "qmaxinst", "qmin", "qmax", "bgscale"]
+    for name in vfloats:
+        assert isinstance(hdata.get(name), float)
+
+    # Check the following are NOT floats
+    vnfloats = ["composition", "rmax", "rmin", "rstep", "rpoly"]
+    for name in vnfloats:
+        assert not isinstance(hdata.get(name), float)

--- a/tests/diffpy/utils/parsers/test_loaddata.py
+++ b/tests/diffpy/utils/parsers/test_loaddata.py
@@ -15,8 +15,11 @@ def test_loadData_default(datafile):
     d2c = np.array([[3, 31], [4, 32], [5, 33]])
 
     with pytest.raises(IOError) as err:
-        loadData("doesnotexist")
-    assert "No such file or directory" in str(err.value)
+        loadData("doesnotexist.txt")
+    assert (
+        str(err.value)
+        == "File doesnotexist.txt cannot be found. Please rerun the program specifying a valid filename."
+    )
 
     # The default minrows=10 makes it read from the third line
     d = loadData(loaddata01)


### PR DESCRIPTION
Closes https://github.com/diffpy/diffpy.utils/issues/161 - since we may deprecate `loadData` to `load_data` or so, spent 5-10 mins to refactor this code. 