### PR TITLE
add deprecation warning to resample function

### DIFF
--- a/news/resample-dep-warning.rst
+++ b/news/resample-dep-warning.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Deprecation warning for resample function in resampler
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/resampler.py
+++ b/src/diffpy/utils/resampler.py
@@ -15,6 +15,8 @@
 
 """Various utilities related to data parsing and manipulation."""
 
+import warnings
+
 import numpy
 
 
@@ -96,6 +98,13 @@ def resample(r, s, dr):
     -------
     Returns resampled (r, s).
     """
+
+    warnings.warn(
+        "The 'resample' function is deprecated and will be removed in a future release. \n"
+        "Please use 'wsinterp' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     dr0 = r[1] - r[0]  # Constant timestep
 


### PR DESCRIPTION
closes #139

Only adding a deprecation warning as per discussion with @Sparks29032 in #145 

Warning looks like this:
<img width="1037" alt="Screenshot 2024-11-23 at 11 27 53 PM" src="https://github.com/user-attachments/assets/850eed9e-df2c-4bd2-a791-156578d4349b">
