### PR TITLE
add deprecation warning to resample function

### DIFF
--- a/news/resampler-dep-warn.rst
+++ b/news/resampler-dep-warn.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Deprecation warning for resample function in resampler
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/resampler-dep-warn.rst
+++ b/news/resampler-dep-warn.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Deprecation warning for resample function in resampler
+* <news item>
 
 **Changed:**
 
@@ -8,7 +8,7 @@
 
 **Deprecated:**
 
-* <news item>
+* Deprecation warning for resample function in resampler
 
 **Removed:**
 

--- a/news/resampler-dep-warn.rst
+++ b/news/resampler-dep-warn.rst
@@ -8,7 +8,7 @@
 
 **Deprecated:**
 
-* Deprecation warning for resample function in resampler
+* resample function in resampler. Replaced with wsinterp with better functionality.
 
 **Removed:**
 

--- a/src/diffpy/utils/resampler.py
+++ b/src/diffpy/utils/resampler.py
@@ -15,6 +15,8 @@
 
 """Various utilities related to data parsing and manipulation."""
 
+import warnings
+
 import numpy
 
 
@@ -96,6 +98,13 @@ def resample(r, s, dr):
     -------
     Returns resampled (r, s).
     """
+
+    warnings.warn(
+        "The 'resample' function is deprecated and will be removed in a future release (3.8.0). \n"
+        "'resample' has been renamed 'wsinterp' to better reflect functionality. Please use 'wsinterp' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     dr0 = r[1] - r[0]  # Constant timestep
 


### PR DESCRIPTION
closes #139

as per discussion in #180 warnings.warn passes pytest under python 3.13, 3.12, 3.11

@sbillinge @bobleesj ready for review

<img width="890" alt="Screenshot 2024-12-07 at 5 16 14 PM" src="https://github.com/user-attachments/assets/2e5349b9-b0ed-49b8-8796-f57b7c099b96">
