### PR TITLE
Rename `input_scattering_quantity` to `input_data` in `DiffractionObject` init

### DIFF
--- a/news/mv-input-scattering-quan.rst
+++ b/news/mv-input-scattering-quan.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Rename `input_scattering_quantity` to `input_data` in `DiffractionObject` init
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/diffraction_objects.py
+++ b/src/diffpy/utils/diffraction_objects.py
@@ -53,7 +53,7 @@ class DiffractionObject:
         if yarray is None:
             yarray = np.empty(0)
 
-        self.insert_scattering_quantity(xarray, yarray, xtype)
+        self.input_data(xarray, yarray, xtype)
 
     def __eq__(self, other):
         if not isinstance(other, DiffractionObject):
@@ -317,7 +317,7 @@ class DiffractionObject:
         self.dmin = np.nanmin(self._all_arrays[:, 3], initial=np.inf)
         self.dmax = np.nanmax(self._all_arrays[:, 3], initial=0.0)
 
-    def insert_scattering_quantity(
+    def input_data(
         self,
         xarray,
         yarray,

--- a/src/diffpy/utils/diffraction_objects.py
+++ b/src/diffpy/utils/diffraction_objects.py
@@ -29,7 +29,7 @@ def _xtype_wmsg(xtype):
 def _setter_wmsg(attribute):
     return (
         f"Direct modification of attribute '{attribute}' is not allowed. "
-        f"Please use 'insert_scattering_quantity' to modify '{attribute}'.",
+        f"Please use 'input_data' to modify '{attribute}'.",
     )
 
 
@@ -351,7 +351,7 @@ class DiffractionObject:
         if len(xarray) != len(yarray):
             raise ValueError(
                 "'xarray' and 'yarray' must have the same length. "
-                "Please re-initialize 'DiffractionObject' or re-run the method 'insert_scattering_quantity' "
+                "Please re-initialize 'DiffractionObject' or re-run the method 'input_data' "
                 "with 'xarray' and 'yarray' of identical length."
             )
 

--- a/tests/test_diffraction_objects.py
+++ b/tests/test_diffraction_objects.py
@@ -364,7 +364,7 @@ def test_all_array_setter():
     with pytest.raises(
         AttributeError,
         match="Direct modification of attribute 'all_arrays' is not allowed. "
-        "Please use 'insert_scattering_quantity' to modify 'all_arrays'.",
+        "Please use 'input_data' to modify 'all_arrays'.",
     ):
         actual_do.all_arrays = np.empty((4, 4))
 
@@ -373,7 +373,7 @@ def test_xarray_yarray_length_mismatch():
     with pytest.raises(
         ValueError,
         match="'xarray' and 'yarray' must have the same length. "
-        "Please re-initialize 'DiffractionObject' or re-run the method 'insert_scattering_quantity' "
+        "Please re-initialize 'DiffractionObject' or re-run the method 'input_data' "
         "with 'xarray' and 'yarray' of identical length",
     ):
         DiffractionObject(xarray=np.array([1.0, 2.0]), yarray=np.array([0.0, 0.0, 0.0]))
@@ -391,7 +391,7 @@ def test_input_xtype_setter():
     with pytest.raises(
         AttributeError,
         match="Direct modification of attribute 'input_xtype' is not allowed. "
-        "Please use 'insert_scattering_quantity' to modify 'input_xtype'.",
+        "Please use 'input_data' to modify 'input_xtype'.",
     ):
         do.input_xtype = "q"
 


### PR DESCRIPTION
Closes https://github.com/diffpy/diffpy.utils/issues/212

Since we are doing a big API migration, didn't add `deprecation warnings` if that's okay. 