### PR TITLE
Add doc build GitHub CI yml file

### DIFF
--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -1,0 +1,16 @@
+name: Deploy Documentation on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  docs:
+    permissions:
+      contents: write
+    uses: Billingegroup/release-scripts/.github/workflows/_publish-docs-on-release.yml@v0
+    with:
+      project: diffpy.utils
+      c_extension: false
+      headless: false


### PR DESCRIPTION
Back in the days, we used to have this combined within the release script but we've then decided to have it as a separate .yml file so that we can run via workflow dispatch easily. 