### PR TITLE
Refactor `test-on-xtype` test function 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 import json
 from pathlib import Path
 
+import numpy as np
 import pytest
+
+from diffpy.utils.diffraction_objects import DiffractionObject
 
 
 @pytest.fixture
@@ -28,3 +31,8 @@ def datafile():
         return base_path / filename
 
     return _load
+
+
+@pytest.fixture
+def do_minimal_tth():
+    return DiffractionObject(wavelength=2 * np.pi, xarray=np.array([30, 60]), yarray=np.array([1, 2]), xtype="tth")

--- a/tests/test_diffraction_objects.py
+++ b/tests/test_diffraction_objects.py
@@ -163,12 +163,20 @@ def test_diffraction_objects_equality(inputs1, inputs2, expected):
     assert (do_1 == do_2) == expected
 
 
-def test_on_xtype():
-    do = DiffractionObject(wavelength=2 * np.pi, xarray=np.array([30, 60]), yarray=np.array([1, 2]), xtype="tth")
-    assert np.allclose(do.on_xtype("tth"), [np.array([30, 60]), np.array([1, 2])])
-    assert np.allclose(do.on_xtype("2theta"), [np.array([30, 60]), np.array([1, 2])])
-    assert np.allclose(do.on_xtype("q"), [np.array([0.51764, 1]), np.array([1, 2])])
-    assert np.allclose(do.on_xtype("d"), [np.array([12.13818, 6.28319]), np.array([1, 2])])
+@pytest.mark.parametrize(
+    "input_xtype, expected_xarray",
+    [
+        ("tth", np.array([30, 60])),
+        ("2theta", np.array([30, 60])),
+        ("q", np.array([0.51764, 1])),
+        ("d", np.array([12.13818, 6.28319])),
+    ],
+)
+def test_on_xtype(input_xtype, expected_xarray, do_minimal_tth):
+    do = do_minimal_tth
+    result = do.on_xtype(input_xtype)
+    assert np.allclose(result[0], expected_xarray)
+    assert np.allclose(result[1], np.array([1, 2]))
 
 
 def test_init_invalid_xtype():

--- a/tests/test_diffraction_objects.py
+++ b/tests/test_diffraction_objects.py
@@ -164,7 +164,7 @@ def test_diffraction_objects_equality(inputs1, inputs2, expected):
 
 
 @pytest.mark.parametrize(
-    "input_xtype, expected_xarray",
+    "xtype, expected_xarray",
     [
         ("tth", np.array([30, 60])),
         ("2theta", np.array([30, 60])),
@@ -172,11 +172,11 @@ def test_diffraction_objects_equality(inputs1, inputs2, expected):
         ("d", np.array([12.13818, 6.28319])),
     ],
 )
-def test_on_xtype(input_xtype, expected_xarray, do_minimal_tth):
+def test_on_xtype(xtype, expected_xarray, do_minimal_tth):
     do = do_minimal_tth
-    result = do.on_xtype(input_xtype)
-    assert np.allclose(result[0], expected_xarray)
-    assert np.allclose(result[1], np.array([1, 2]))
+    actual_xrray, actual_yarray = do.on_xtype(xtype)
+    assert np.allclose(actual_xrray, expected_xarray)
+    assert np.allclose(actual_yarray, np.array([1, 2]))
 
 
 def test_init_invalid_xtype():


### PR DESCRIPTION
Closes https://github.com/diffpy/diffpy.utils/issues/229 - Refactor test_on_xtype() using @pytest.mark.parametrize and conftest.py 