### PR TITLE
add deprecation warning to resample function

### DIFF
--- a/news/resample-dep.rst
+++ b/news/resample-dep.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* `resample` function in resampler. Replaced with `wsinterp` with better functionality.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/resampler.py
+++ b/src/diffpy/utils/resampler.py
@@ -15,6 +15,8 @@
 
 """Various utilities related to data parsing and manipulation."""
 
+import warnings
+
 import numpy as np
 
 
@@ -96,6 +98,13 @@ def resample(r, s, dr):
     -------
     Returns resampled (r, s).
     """
+
+    warnings.warn(
+        "The 'resample' function is deprecated and will be removed in a future release (3.8.0). \n"
+        "'resample' has been renamed 'wsinterp' to better reflect functionality. Please use 'wsinterp' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     dr0 = r[1] - r[0]  # Constant timestep
 


### PR DESCRIPTION
closes #139 

as per discussion in #180 and #207 warnings.warn passes pytest under python 3.13, 3.12, 3.11

@sbillinge ready for review

<img width="890" alt="Screenshot 2024-12-07 at 5 16 14 PM" src="https://github.com/user-attachments/assets/3feb98f1-f8f1-4c66-8103-42ea6800c91f" />

