### PR TITLE
implement a skip_config_creation option in get_user_info

### DIFF
--- a/news/config.rst
+++ b/news/config.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* allow `get_user_info` to override user input interruption, even if there are no configuration files.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/tools.py
+++ b/src/diffpy/utils/tools.py
@@ -91,7 +91,7 @@ def _create_global_config(args):
     return return_bool
 
 
-def get_user_info(args=None):
+def get_user_info(args=None, skip_config_creation=False):
     """
     Get username and email configuration.
 
@@ -114,6 +114,9 @@ def get_user_info(args=None):
     config_bool = True
     global_config = load_config(Path().home() / "diffpyconfig.json")
     local_config = load_config(Path().cwd() / "diffpyconfig.json")
+    if skip_config_creation:
+        config = _sorted_merge(clean_dict(global_config), clean_dict(local_config), clean_dict(args))
+        return config
     if global_config is None and local_config is None:
         print(
             "No global configuration file was found containing "

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,6 +22,9 @@ def _run_tests(inputs, expected):
     config = get_user_info(args)
     assert config.get("username") == expected_username
     assert config.get("email") == expected_email
+    config = get_user_info(args, skip_config_creation=True)
+    assert config.get("username") == expected_username
+    assert config.get("email") == expected_email
 
 
 params_user_info_with_home_conf_file = [
@@ -118,7 +121,20 @@ def test_get_user_info_no_conf_file_no_inputs(monkeypatch, inputsa, inputsb, exp
     os.remove(Path().home() / "diffpyconfig.json")
     inp_iter = iter(inputsb)
     monkeypatch.setattr("builtins.input", lambda _: next(inp_iter))
-    _run_tests(inputsa, expected)
+
+    args = {"username": inputsa[0], "email": inputsa[1]}
+    expected_username, expected_email = expected
+
+    # Test with user inputs
+    config = get_user_info(args)
+    assert config.get("username") == expected_username
+    assert config.get("email") == expected_email
+
+    # Test skipping config creation, expecting None values
+    config = get_user_info(args, skip_config_creation=True)
+    assert config.get("username") is None
+    assert config.get("email") is None
+
     confile = Path().home() / "diffpyconfig.json"
     assert confile.exists() is False
 


### PR DESCRIPTION
closes #244 
@sbillinge ready for some feedback
btw I see in the docs you used `get_user_data` instead of `get_user_info` at a couple places, which seems to be a better name, shall we change to `get_user_data` instead?