### PR TITLE
Remove 6 pytest warnings with capturing wavelength warnings

### DIFF
--- a/news/pytest-warnings-others.rst
+++ b/news/pytest-warnings-others.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -171,8 +171,13 @@ def test_d_to_q(d, expected_q):
         ),
     ],
 )
-def test_tth_to_d(wavelength, tth, expected_d):
-    actual_d = tth_to_d(tth, wavelength)
+def test_tth_to_d(wavelength, tth, expected_d, wavelength_warning_msg):
+    if wavelength is None:
+        with pytest.warns(UserWarning, match=re.escape(wavelength_warning_msg)):
+            actual_d = tth_to_d(tth, wavelength)
+    else:
+        actual_d = tth_to_d(tth, wavelength)
+
     assert np.allclose(actual_d, expected_d)
 
 
@@ -221,8 +226,13 @@ def test_tth_to_d_invalid(wavelength, tth, expected_error_type, expected_error_m
         ),
     ],
 )
-def test_d_to_tth(wavelength, d, expected_tth):
-    actual_tth = d_to_tth(d, wavelength)
+def test_d_to_tth(wavelength, d, expected_tth, wavelength_warning_msg):
+    if wavelength is None:
+        with pytest.warns(UserWarning, match=re.escape(wavelength_warning_msg)):
+            actual_tth = d_to_tth(d, wavelength)
+    else:
+        actual_tth = d_to_tth(d, wavelength)
+
     assert np.allclose(actual_tth, expected_tth)
 
 


### PR DESCRIPTION
Making smaller PRs since @sbillinge is on the road.