### PR TITLE
Catch `wavelength=none` warnings in DiffractionObject

### DIFF
--- a/news/pytest-wavelength-warnings.rst
+++ b/news/pytest-wavelength-warnings.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* unit test for expected warning when no wavelength is provided for DiffractionObject init
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_diffraction_objects.py
+++ b/tests/test_diffraction_objects.py
@@ -12,9 +12,9 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
 
 
 @pytest.mark.parametrize(
-    "do_args_1, do_args_2, expected_equality",
+    "do_args_1, do_args_2, expected_equality, warning_expected",
     [
-        # Test when __eqal__ returns True and False
+        # Test when __eq__ returns True and False
         # Identical args, expect equality
         (
             {
@@ -36,6 +36,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1},
             },
             True,
+            False
         ),
         (  # Different names, expect inequality
             {
@@ -53,6 +54,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
+            True
         ),
         (  # One without wavelength, expect inequality
             {
@@ -69,6 +71,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
+            True
         ),
         (  # Different wavelengths, expect inequality
             {
@@ -86,6 +89,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
+            False
         ),
         (  # Different scat_quantity, expect inequality
             {
@@ -103,6 +107,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
+            True
         ),
         (  # Different q xarray values, expect inequality
             {
@@ -117,6 +122,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
+            True
         ),
         (  # Different metadata, expect inequality
             {
@@ -132,12 +138,18 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
+            True
         ),
     ],
 )
-def test_diffraction_objects_equality(do_args_1, do_args_2, expected_equality):
-    do_1 = DiffractionObject(**do_args_1)
-    do_2 = DiffractionObject(**do_args_2)
+def test_diffraction_objects_equality(do_args_1, do_args_2, expected_equality, warning_expected, wavelength_warning_msg):
+    if warning_expected:
+        with pytest.warns(UserWarning, match=re.escape(wavelength_warning_msg)):
+            do_1 = DiffractionObject(**do_args_1)
+            do_2 = DiffractionObject(**do_args_2)
+    else:
+        do_1 = DiffractionObject(**do_args_1)
+        do_2 = DiffractionObject(**do_args_2)
     assert (do_1 == do_2) == expected_equality
 
 

--- a/tests/test_diffraction_objects.py
+++ b/tests/test_diffraction_objects.py
@@ -36,7 +36,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1},
             },
             True,
-            False
+            False,
         ),
         (  # Different names, expect inequality
             {
@@ -54,7 +54,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
-            True
+            True,
         ),
         (  # One without wavelength, expect inequality
             {
@@ -71,7 +71,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
-            True
+            True,
         ),
         (  # Different wavelengths, expect inequality
             {
@@ -89,7 +89,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
-            False
+            False,
         ),
         (  # Different scat_quantity, expect inequality
             {
@@ -107,7 +107,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
-            True
+            True,
         ),
         (  # Different q xarray values, expect inequality
             {
@@ -122,7 +122,7 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
-            True
+            True,
         ),
         (  # Different metadata, expect inequality
             {
@@ -138,11 +138,13 @@ from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
                 "metadata": {"thing1": 1, "thing2": "thing2"},
             },
             False,
-            True
+            True,
         ),
     ],
 )
-def test_diffraction_objects_equality(do_args_1, do_args_2, expected_equality, warning_expected, wavelength_warning_msg):
+def test_diffraction_objects_equality(
+    do_args_1, do_args_2, expected_equality, warning_expected, wavelength_warning_msg
+):
     if warning_expected:
         with pytest.warns(UserWarning, match=re.escape(wavelength_warning_msg)):
             do_1 = DiffractionObject(**do_args_1)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -27,7 +27,6 @@ from diffpy.utils.transforms import d_to_q, d_to_tth, q_to_d, q_to_tth, tth_to_d
     ],
 )
 def test_q_to_tth(wavelength, q, expected_tth, wavelength_warning_msg):
-
     if wavelength is None:
         with pytest.warns(UserWarning, match=re.escape(wavelength_warning_msg)):
             actual_tth = q_to_tth(q, wavelength)


### PR DESCRIPTION
Done..

```
======= 100 passed, 9 warnings in 0.20s ==========
```

9 warnings left - all coming from `divide by zero` error. I will fix this once https://github.com/diffpy/diffpy.utils/pull/260 is merged.