### PR TITLE
Apply `prettier` to pre-commit for automatic linting of `.md` `.yaml` files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,14 +1,14 @@
 coverage:
   status:
-    project:  # more options at https://docs.codecov.com/docs/commit-status
+    project: # more options at https://docs.codecov.com/docs/commit-status
       default:
         target: auto # use the coverage from the base commit, fail if coverage is lower
-        threshold: 0%  # allow the coverage to drop by
+        threshold: 0% # allow the coverage to drop by
 
 comment:
   layout: " diff, flags, files"
   behavior: default
   require_changes: false
-  require_base: false  # [true :: must have a base report to post]
-  require_head: false  # [true :: must have a head report to post]
+  require_base: false # [true :: must have a base report to post]
+  require_head: false # [true :: must have a head report to post]
   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -12,11 +12,11 @@ assignees: ""
 - [ ] All the badges on the README are passing.
 - [ ] License information is verified as correct. If you are unsure, please comment below.
 - [ ] Locally rendered documentation contains all appropriate pages, including API references (check no modules are
-  missing), tutorials, and other human-written text is up-to-date with any changes in the code.
+      missing), tutorials, and other human-written text is up-to-date with any changes in the code.
 - [ ] Installation instructions in the README, documentation, and the website (e.g., diffpy.org) are updated.
 - [ ] Successfully run any tutorial examples or do functional testing with the latest Python version.
 - [ ] Grammar and writing quality are checked (no typos).
-- [ ] Install `pip install build twine`, run  `python -m build` and `twine check dist/*` to ensure that the package can be built and is correctly formatted for PyPI release.
+- [ ] Install `pip install build twine`, run `python -m build` and `twine check dist/*` to ensure that the package can be built and is correctly formatted for PyPI release.
 
 Please mention @sbillinge here when you are ready for PyPI/GitHub release. Include any additional comments necessary, such as version information and details about the pre-release here:
 
@@ -42,5 +42,5 @@ Please let @sbillinge know that all checks are done and the package is ready for
 
 <!-- Before closing this issue, please complete the following: -->
 
-- [ ]  Run tutorial examples and conduct functional testing using the installation guide in the README. Attach screenshots/results as comments.
-- [ ]  Documentation (README, tutorials, API references, and websites) is deployed without broken links or missing figures.
+- [ ] Run tutorial examples and conduct functional testing using the installation guide in the README. Attach screenshots/results as comments.
+- [ ] Documentation (README, tutorials, API references, and websites) is deployed without broken links or missing figures.

--- a/.github/workflows/build-wheel-release-upload.yml
+++ b/.github/workflows/build-wheel-release-upload.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '*'  # Trigger on all tags initially, but tag and release privilege are verified in _build-wheel-release-upload.yml
+      - "*" # Trigger on all tags initially, but tag and release privilege are verified in _build-wheel-release-upload.yml
 
 jobs:
   release:

--- a/.github/workflows/check-news-item.yml
+++ b/.github/workflows/check-news-item.yml
@@ -3,7 +3,7 @@ name: Check for News
 on:
   pull_request_target:
     branches:
-    - main
+      - main
 
 jobs:
   check-news-item:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 default_language_version:
-    python: python3
+  python: python3
 ci:
-    autofix_commit_msg: |
-        [pre-commit.ci] auto fixes from pre-commit hooks
-    autofix_prs: true
-    autoupdate_branch: 'pre-commit-autoupdate'
-    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: monthly
-    skip: [no-commit-to-branch]
-    submodules: false
+  autofix_commit_msg: |
+    [pre-commit.ci] auto fixes from pre-commit hooks
+  autofix_prs: true
+  autoupdate_branch: "pre-commit-autoupdate"
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  skip: [no-commit-to-branch]
+  submodules: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -47,6 +47,13 @@ repos:
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
-    - id: codespell
-      additional_dependencies:
-        - tomli
+      - id: codespell
+        additional_dependencies:
+          - tomli
+  # prettier - multi formatter
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - "prettier@^3.2.4"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,13 +44,14 @@ repos:
         name: Prevent Commit to Main Branch
         args: ["--branch", "main"]
         stages: [pre-commit]
+  # codespell - spell checker for source code
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli
-  # prettier - multi formatter
+  # prettier - multi formatter for json, yaml, md
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
     hooks:

--- a/news/prettier-pre-commit.rst
+++ b/news/prettier-pre-commit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* prettier pre-commit hook for automatic linting of .yml, .json, and .md files
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge 

Do we want to automate linting for `.md` and `.yaml` files with the following addition to `.pre-commit-config.yaml`?

```
  # prettier - multi formatter for json, yaml, md
  - repo: https://github.com/pre-commit/mirrors-prettier
    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
    hooks:
      - id: prettier
        additional_dependencies:
          - "prettier@^3.2.4"
```

No manual edits have been made.