### PR TITLE
refactor  to separate getting info and creating config files

### DIFF
--- a/news/userinfo.rst
+++ b/news/userinfo.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Refactor get_user_info to separate the tasks of getting the info from config files
+  and creating config files when they are missing.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/tools.py
+++ b/src/diffpy/utils/tools.py
@@ -92,22 +92,38 @@ def _create_global_config(args):
 
 def get_user_info(owner_name=None, owner_email=None, owner_orcid=None):
     """
-    Get username, email and orcid configuration.
+    Get name, email and orcid of the owner/user from various sources and return it as a metadata dictionary
 
-    First attempts to load config file from global and local paths.
-    If neither exists, creates a global config file.
-    It prioritizes values from args, then local, then global.
-    Removes invalid global config file if creation is needed, replacing it with empty username and email.
+    The function looks for the information in json format configuration files with the name 'diffpyconfig.json'.
+    These can be in the user's home directory and in the current working directory.  The information in the
+    config files are combined, with the local config overriding the home-directory one.  Values for
+    owner_name, owner_email, and owner_orcid may be passed in to the function and these override the values
+    in the config files.
+
+    A template for the config file is below.  Create a text file called 'diffpyconfig.json' in your home directory
+    and copy-paste the template into it, editing it with your real information.
+    {
+      "owner_name": "<your name as you would like it stored with your data>>",
+      "owner_email": "<your_associated_email>>@email.com",
+      "owner_orcid": "<your_associated_orcid if you would like this stored with your data>>"
+    }
+    You may also store any other gloabl-level information that you would like associated with your
+    diffraction data in this file
 
     Parameters
     ----------
-    args argparse.Namespace
-        The arguments from the parser, default is None.
+    owner_name: string, optional, default is the value stored in the global or local config file.
+        The name of the user who will show as owner in the metadata that is stored with the data
+    owner_email: string, optional, default is the value stored in the global or local config file.
+        The email of the user/owner
+    owner_name:  string, optional, default is the value stored in the global or local config file.
+        The ORCID id of the user/owner
 
     Returns
     -------
-    dict or None:
-        The dictionary containing username and email with corresponding values.
+    dict:
+        The dictionary containing username, email and orcid of the user/owner, and any other information
+        stored in the global or local config files.
 
     """
     runtime_info = {"owner_name": owner_name, "owner_email": owner_email, "owner_orcid": owner_orcid}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,14 +12,16 @@ def user_filesystem(tmp_path):
     base_dir = Path(tmp_path)
     home_dir = base_dir / "home_dir"
     home_dir.mkdir(parents=True, exist_ok=True)
-    cwd_dir = base_dir / "cwd_dir"
+    cwd_dir = home_dir / "cwd_dir"
     cwd_dir.mkdir(parents=True, exist_ok=True)
-
-    home_config_data = {"username": "home_username", "email": "home@email.com"}
+    home_config_data = {
+        "owner_name": "home_ownername",
+        "owner_email": "home@email.com",
+        "owner_orcid": "home_orcid",
+    }
     with open(home_dir / "diffpyconfig.json", "w") as f:
         json.dump(home_config_data, f)
-
-    yield tmp_path
+    yield home_dir, cwd_dir
 
 
 @pytest.fixture

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,11 +7,11 @@ import pytest
 
 from diffpy.utils.tools import get_package_info, get_user_info
 
-
-def _setup_dirs(user_filesystem):
-    home_dir, cwd_dir = user_filesystem.home_dir, user_filesystem.cwd_dir
-    os.chdir(cwd_dir)
-    return home_dir
+# def _setup_dirs(monkeypatch, user_filesystem):
+#     home_dir, cwd_dir = user_filesystem.home_dir, user_filesystem.cwd_dir
+#     os.chdir(cwd_dir)
+#     return home_dir
+#
 
 
 def _run_tests(inputs, expected):
@@ -138,8 +138,8 @@ def test_get_user_info_with_home_conf_file(runtime_inputs, expected, user_filesy
     ],
 )
 def test_get_user_info_with_local_conf_file(runtime_inputs, expected, user_filesystem, mocker):
-    # user_filesystem[0] is tmp_dir/home_dir with the global config file in it, user_filesystem[1] i
-    #   s tmp_dir/cwd_dir
+    # user_filesystem[0] is tmp_dir/home_dir with the global config file in it, user_filesystem[1]
+    #   is tmp_dir/cwd_dir
     mocker.patch.object(Path, "home", return_value=user_filesystem[0])
     os.chdir(user_filesystem[1])
     local_config_data = {"owner_name": "cwd_ownername", "owner_email": "cwd@email.com"}
@@ -149,27 +149,27 @@ def test_get_user_info_with_local_conf_file(runtime_inputs, expected, user_files
     assert actual == expected
 
 
-@pytest.mark.parametrize("inputsa, inputsb, expected", params_user_info_with_no_home_conf_file)
-def test_get_user_info_with_no_home_conf_file(monkeypatch, inputsa, inputsb, expected, user_filesystem):
-    _setup_dirs(monkeypatch, user_filesystem)
-    os.remove(Path().home() / "diffpyconfig.json")
-    inp_iter = iter(inputsb)
-    monkeypatch.setattr("builtins.input", lambda _: next(inp_iter))
-    _run_tests(inputsa, expected)
-    confile = Path().home() / "diffpyconfig.json"
-    assert confile.is_file()
-
-
-@pytest.mark.parametrize("inputsa, inputsb, expected", params_user_info_no_conf_file_no_inputs)
-def test_get_user_info_no_conf_file_no_inputs(monkeypatch, inputsa, inputsb, expected, user_filesystem):
-    _setup_dirs(monkeypatch, user_filesystem)
-    os.remove(Path().home() / "diffpyconfig.json")
-    inp_iter = iter(inputsb)
-    monkeypatch.setattr("builtins.input", lambda _: next(inp_iter))
-    _run_tests(inputsa, expected)
-    confile = Path().home() / "diffpyconfig.json"
-    assert confile.exists() is False
-
+# @pytest.mark.parametrize("inputsa, inputsb, expected", params_user_info_with_no_home_conf_file)
+# def test_get_user_info_with_no_home_conf_file(monkeypatch, inputsa, inputsb, expected, user_filesystem):
+#     _setup_dirs(monkeypatch, user_filesystem)
+#     os.remove(Path().home() / "diffpyconfig.json")
+#     inp_iter = iter(inputsb)
+#     monkeypatch.setattr("builtins.input", lambda _: next(inp_iter))
+#     _run_tests(inputsa, expected)
+#     confile = Path().home() / "diffpyconfig.json"
+#     assert confile.is_file()
+#
+#
+# @pytest.mark.parametrize("inputsa, inputsb, expected", params_user_info_no_conf_file_no_inputs)
+# def test_get_user_info_no_conf_file_no_inputs(monkeypatch, inputsa, inputsb, expected, user_filesystem):
+#     _setup_dirs(monkeypatch, user_filesystem)
+#     os.remove(Path().home() / "diffpyconfig.json")
+#     inp_iter = iter(inputsb)
+#     monkeypatch.setattr("builtins.input", lambda _: next(inp_iter))
+#     _run_tests(inputsa, expected)
+#     confile = Path().home() / "diffpyconfig.json"
+#     assert confile.exists() is False
+#
 
 params_package_info = [
     (["diffpy.utils", None], {"package_info": {"diffpy.utils": "3.3.0"}}),


### PR DESCRIPTION
closes #245 
replaces #253 

@yucongalicechen @bobleesj ready for review.  I will put the config-file creation workflow on another PR

Commented text will be reused (and removed from here) in a separate function for creating a missing global config file in a future PR.