### PR TITLE
Fix `get_array_index` returns `int` instead of `list` in DiffractionObject

### DIFF
--- a/news/get-index.rst
+++ b/news/get-index.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* return type of `get_array_index` method in `DiffractionObject` to return integer instead of list
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/diffraction_objects.py
+++ b/src/diffpy/utils/diffraction_objects.py
@@ -331,29 +331,29 @@ class DiffractionObject:
     def uuid(self, _):
         raise AttributeError(_setter_wmsg("uuid"))
 
-    def get_array_index(self, value, xtype=None):
+    def get_array_index(self, xtype, xvalue):
         """Return the index of the closest value in the array associated with
-        the specified xtype.
+        the specified xtype and the value provided.
 
         Parameters
         ----------
-        xtype str
-            the xtype used to access the array
-        value float
-            the target value to search for
+        xtype : str
+            The type of the independent variable in `xarray`. Must be one of {*XQUANTITIES}.
+        xvalue : float
+            The value of the xtype to find the closest index for.
 
         Returns
         -------
-        list
-            The list containing the index of the closest value in the array.
+        int
+            The index of the closest value in the array associated with the specified xtype and the value provided.
         """
 
         xtype = self._input_xtype
-        array = self.on_xtype(xtype)[0]
-        if len(array) == 0:
+        xarray = self.on_xtype(xtype)[0]
+        if len(xarray) == 0:
             raise ValueError(f"The '{xtype}' array is empty. Please ensure it is initialized.")
-        i = (np.abs(array - value)).argmin()
-        return i
+        index = (np.abs(xarray - xvalue)).argmin()
+        return index
 
     def _set_arrays(self, xarray, yarray, xtype):
         self._all_arrays = np.empty(shape=(len(xarray), 4))

--- a/tests/test_diffraction_objects.py
+++ b/tests/test_diffraction_objects.py
@@ -364,7 +364,7 @@ def test_scale_to_bad(org_do_args, target_do_args, scale_inputs):
                 "xtype": "tth",
                 "value": 30.005,
             },
-            [0],
+            0,
         ),
         (  # C2: Target value lies in the array, expect the (first) closest index
             {
@@ -377,7 +377,7 @@ def test_scale_to_bad(org_do_args, target_do_args, scale_inputs):
                 "xtype": "tth",
                 "value": 45,
             },
-            [0],
+            0,
         ),
         (
             {
@@ -390,7 +390,7 @@ def test_scale_to_bad(org_do_args, target_do_args, scale_inputs):
                 "xtype": "q",
                 "value": 0.25,
             },
-            [0],
+            0,
         ),
         # C3: Target value out of the range, expect the closest index
         (  # 1. Test with xtype of "q"
@@ -404,7 +404,7 @@ def test_scale_to_bad(org_do_args, target_do_args, scale_inputs):
                 "xtype": "q",
                 "value": 0.1,
             },
-            [0],
+            0,
         ),
         (  # 2. Test with xtype of "tth"
             {
@@ -417,20 +417,20 @@ def test_scale_to_bad(org_do_args, target_do_args, scale_inputs):
                 "xtype": "tth",
                 "value": 63,
             },
-            [1],
+            1,
         ),
     ],
 )
 def test_get_array_index(do_args, get_array_index_inputs, expected_index):
     do = DiffractionObject(**do_args)
-    actual_index = do.get_array_index(get_array_index_inputs["value"], get_array_index_inputs["xtype"])
+    actual_index = do.get_array_index(get_array_index_inputs["xtype"], get_array_index_inputs["value"])
     assert actual_index == expected_index
 
 
 def test_get_array_index_bad():
     do = DiffractionObject(wavelength=2 * np.pi, xarray=np.array([]), yarray=np.array([]), xtype="tth")
     with pytest.raises(ValueError, match=re.escape("The 'tth' array is empty. Please ensure it is initialized.")):
-        do.get_array_index(value=30)
+        do.get_array_index(xtype="tth", xvalue=30)
 
 
 def test_dump(tmp_path, mocker):


### PR DESCRIPTION
Closes https://github.com/diffpy/diffpy.utils/issues/279