### PR TITLE
fix: compare values and shape of `xarray` values before applying operations between 2 DiffractionObjects

### DIFF
--- a/news/no-news.rst
+++ b/news/no-news.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: just making sure the previous add, mul, div, and sub tests are working as expected.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/utils/diffraction_objects.py
+++ b/src/diffpy/utils/diffraction_objects.py
@@ -14,9 +14,10 @@ DQUANTITIES = ["d", "dspace"]
 XQUANTITIES = ANGLEQUANTITIES + DQUANTITIES + QQUANTITIES
 XUNITS = ["degrees", "radians", "rad", "deg", "inv_angs", "inv_nm", "nm-1", "A-1"]
 
-y_grid_length_mismatch_emsg = (
-    "The two objects have different y-array lengths. "
-    "Please ensure the length of the y-value during initialization is identical."
+x_values_not_equal_emsg = (
+    "The two objects have different values in x arrays (my_do.all_arrays[:, [1, 2, 3]]). "
+    "Please ensure the x values of the two objects are identical by re-instantiating "
+    "the DiffractionObject with the correct x value inputs."
 )
 
 invalid_add_type_emsg = (
@@ -255,7 +256,9 @@ class DiffractionObject:
             raise TypeError(invalid_add_type_emsg)
         if isinstance(other, DiffractionObject):
             if self.all_arrays.shape != other.all_arrays.shape:
-                raise ValueError(y_grid_length_mismatch_emsg)
+                raise ValueError(x_values_not_equal_emsg)
+            if not np.allclose(self.all_arrays[:, [1, 2, 3]], other.all_arrays[:, [1, 2, 3]]):
+                raise ValueError(x_values_not_equal_emsg)
 
     @property
     def all_arrays(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,8 +81,9 @@ def invalid_add_type_error_msg():
 
 
 @pytest.fixture
-def y_grid_size_mismatch_error_msg():
+def x_values_not_equal_error_msg():
     return (
-        "The two objects have different y-array lengths. "
-        "Please ensure the length of the y-value during initialization is identical."
+        "The two objects have different values in x arrays (my_do.all_arrays[:, [1, 2, 3]]). "
+        "Please ensure the x values of the two objects are identical by re-instantiating "
+        "the DiffractionObject with the correct x value inputs."
     )

--- a/tests/test_diffraction_objects.py
+++ b/tests/test_diffraction_objects.py
@@ -780,28 +780,28 @@ def test_scalar_operations(operation, starting_yarray, scalar_value, expected_ya
 
 
 @pytest.mark.parametrize(
-    "operation, " "expected_do_1_all_arrays_with_y_modified, " "expected_do_2_all_arrays_with_y_modified",
+    "operation, expected_do_1_all_arrays_with_y_modified, expected_do_2_all_arrays_with_y_modified",
     [
         # Test addition, subtraction, multiplication, and division of two DO objects
         (  # Test addition of two DO objects, expect combined yarray values
             "add",
             np.array([[2.0, 0.51763809, 30.0, 12.13818192], [4.0, 1.0, 60.0, 6.28318531]]),
-            np.array([[2.0, 6.28318531, 100.70777771, 1], [4.0, 3.14159265, 45.28748053, 2.0]]),
+            np.array([[2.0, 0.51763809, 30.0, 12.13818192], [4.0, 1.0, 60.0, 6.28318531]]),
         ),
         (  # Test subtraction of two DO objects, expect differences in yarray values
             "sub",
             np.array([[0.0, 0.51763809, 30.0, 12.13818192], [0.0, 1.0, 60.0, 6.28318531]]),
-            np.array([[0.0, 6.28318531, 100.70777771, 1], [0.0, 3.14159265, 45.28748053, 2.0]]),
+            np.array([[0.0, 0.51763809, 30.0, 12.13818192], [0.0, 1.0, 60.0, 6.28318531]]),
         ),
         (  # Test multiplication of two DO objects, expect multiplication in yarray values
             "mul",
             np.array([[1.0, 0.51763809, 30.0, 12.13818192], [4.0, 1.0, 60.0, 6.28318531]]),
-            np.array([[1.0, 6.28318531, 100.70777771, 1], [4.0, 3.14159265, 45.28748053, 2.0]]),
+            np.array([[1.0, 0.51763809, 30.0, 12.13818192], [4.0, 1.0, 60.0, 6.28318531]]),
         ),
         (  # Test division of two DO objects, expect division in yarray values
             "div",
             np.array([[1.0, 0.51763809, 30.0, 12.13818192], [1.0, 1.0, 60.0, 6.28318531]]),
-            np.array([[1.0, 6.28318531, 100.70777771, 1], [1.0, 3.14159265, 45.28748053, 2.0]]),
+            np.array([[1.0, 0.51763809, 30.0, 12.13818192], [1.0, 1.0, 60.0, 6.28318531]]),
         ),
     ],
 )
@@ -810,15 +810,14 @@ def test_binary_operator_on_do(
     expected_do_1_all_arrays_with_y_modified,
     expected_do_2_all_arrays_with_y_modified,
     do_minimal_tth,
-    do_minimal_d,
 ):
     do_1 = do_minimal_tth
-    do_2 = do_minimal_d
+    do_2 = do_minimal_tth
     assert np.allclose(
         do_1.all_arrays, np.array([[1.0, 0.51763809, 30.0, 12.13818192], [2.0, 1.0, 60.0, 6.28318531]])
     )
     assert np.allclose(
-        do_2.all_arrays, np.array([[1.0, 6.28318531, 100.70777771, 1], [2.0, 3.14159265, 45.28748053, 2.0]])
+        do_2.all_arrays, np.array([[1.0, 0.51763809, 30.0, 12.13818192], [2.0, 1.0, 60.0, 6.28318531]])
     )
 
     if operation == "add":
@@ -856,13 +855,31 @@ def test_operator_invalid_type(do_minimal_tth, invalid_add_type_error_msg):
 
 
 @pytest.mark.parametrize("operation", ["add", "sub", "mul", "div"])
-def test_operator_invalid_yarray_length(operation, do_minimal, do_minimal_tth, y_grid_size_mismatch_error_msg):
-    # Add two DO objects with different yarray lengths, expect ValueError
+def test_operator_invalid_xarray_values_not_equal(
+    operation, do_minimal_tth, do_minimal_d, x_values_not_equal_error_msg
+):
+    # Add two DO objects with different xarray values but equal in shape, expect ValueError
+    do_1 = do_minimal_tth
+    do_2 = do_minimal_d
+    with pytest.raises(ValueError, match=re.escape(x_values_not_equal_error_msg)):
+        if operation == "add":
+            do_1 + do_2
+        elif operation == "sub":
+            do_1 - do_2
+        elif operation == "mul":
+            do_1 * do_2
+        elif operation == "div":
+            do_1 / do_2
+
+
+@pytest.mark.parametrize("operation", ["add", "sub", "mul", "div"])
+def test_operator_invalid_xarray_shape_not_equal(
+    operation, do_minimal, do_minimal_tth, x_values_not_equal_error_msg
+):
+    # Add two DO objects with different xarrays shape, expect ValueError
     do_1 = do_minimal
     do_2 = do_minimal_tth
-    assert len(do_1.all_arrays[:, 0]) == 0
-    assert len(do_2.all_arrays[:, 0]) == 2
-    with pytest.raises(ValueError, match=re.escape(y_grid_size_mismatch_error_msg)):
+    with pytest.raises(ValueError, match=re.escape(x_values_not_equal_error_msg)):
         if operation == "add":
             do_1 + do_2
         elif operation == "sub":


### PR DESCRIPTION
Closes https://github.com/diffpy/diffpy.utils/issues/298 - 