### PR TITLE
fix: Add `sbillinge` as the designated authorized user for release in  `build-wheel-release-upload.yml`

### DIFF
--- a/.github/workflows/build-wheel-release-upload.yml
+++ b/.github/workflows/build-wheel-release-upload.yml
@@ -11,6 +11,8 @@ jobs:
     uses: Billingegroup/release-scripts/.github/workflows/_build-wheel-release-upload.yml@v0
     with:
       project: diffpy.utils
+      github_admin_username: sbillinge
+
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/news/set-github-admin.rst
+++ b/news/set-github-admin.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* sbillinge username as the authorized admin for GitHub release workflow in `build-wheel-release-upload.yml`
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Closes https://github.com/diffpy/diffpy.utils/issues/304