### PR TITLE
ci: test whether codecov coverage passes (not for merge, testing codecov CI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,5 @@ exclude = '''
   | buck-out
   | build
   | dist
-
-  # The following are specific to Black, you probably don't want those.
-  | blib2to3
-  | tests/data
 )/
 '''


### PR DESCRIPTION
Used to for testing after seeing that `scikit-package` codecov fails here https://github.com/Billingegroup/scikit-package/pull/245