### PR TITLE
skpkg: doc migration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 =============
-Release Notes
+Release notes
 =============
 
 .. current developments

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -8,7 +8,7 @@ Our Pledge
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, caste, color, religion, or sexual
 identity and orientation.
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
         :target: https://diffpy.github.io/diffpy.utils
         :height: 100px
 
-|PyPi| |Forge| |PythonVersion| |PR|
+|PyPI| |Forge| |PythonVersion| |PR|
 
 |CI| |Codecov| |Black| |Tracking|
 
@@ -26,7 +26,7 @@
 
 .. |PR| image:: https://img.shields.io/badge/PR-Welcome-29ab47ff
 
-.. |PyPi| image:: https://img.shields.io/pypi/v/diffpy.utils
+.. |PyPI| image:: https://img.shields.io/pypi/v/diffpy.utils
         :target: https://pypi.org/project/diffpy.utils/
 
 .. |PythonVersion| image:: https://img.shields.io/pypi/pyversions/diffpy.utils
@@ -141,4 +141,9 @@ Before contributing, please read our `Code of Conduct <https://github.com/diffpy
 Contact
 -------
 
-For more information on diffpy.utils please visit the project `web-page <https://diffpy.github.io/>`_ or email Prof. Simon Billinge at sb2896@columbia.edu.
+For more information on diffpy.utils please visit the project `web-page <https://diffpy.github.io/>`_ or email Simon Billinge at sb2896@columbia.edu.
+
+Acknowledgements
+----------------
+
+``diffpy.utils`` is built and maintained with `scikit-package <https://scikit-package.github.io/scikit-package/>`_.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,6 +18,12 @@ import time
 from importlib.metadata import version
 from pathlib import Path
 
+# Attempt to import the version dynamically from GitHub tag.
+try:
+    fullversion = version("diffpy.utils")
+except Exception:
+    fullversion = "No version found. The correct version will appear in the released version."  # noqa: E501
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use Path().resolve() to make it absolute, like shown here.
@@ -43,6 +49,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx_rtd_theme",
+    "sphinx_copybutton",
     "m2r",
 ]
 
@@ -88,6 +95,11 @@ year = today.split()[-1]
 # substitute YEAR in the copyright string
 copyright = copyright.replace("%Y", year)
 
+# For sphinx_copybutton extension.
+# Do not copy "$" for shell commands in code-blocks.
+copybutton_prompt_text = r"^\$ "
+copybutton_prompt_is_regexp = True
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ["build"]
@@ -122,6 +134,14 @@ nitpicky = True
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
+
+html_context = {
+    "display_github": True,
+    "github_user": "diffpy",
+    "github_repo": "diffpy.utils",
+    "github_version": "main",
+    "conf_py_path": "/doc/source/",
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -256,7 +276,13 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ("index", "diffpy.utils", "diffpy.utils Documentation", ab_authors, 1)
+    (
+        "index",
+        "diffpy.utils",
+        "diffpy.utils Documentation",
+        ab_authors,
+        1,
+    )
 ]
 
 # If true, show URL addresses after external links.

--- a/news/doc-migration.rst
+++ b/news/doc-migration.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Support ``scikit-package`` Level 5 standard (https://scikit-package.github.io/scikit-package/).
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
When I built docs locally, I got a lot of warning messages referring to docstring formatting and other doc formatting. However, these warnings persists on the current version of diffpy.utils leading me to believe that there are some formatting issues with the current rst files where the docs exists (which i left unchanged). 