### PR TITLE
docs: fix the example of using `DiffractionObject.get_array_index` in the documentation

### DIFF
--- a/docs/source/examples/diffraction_objects_example.rst
+++ b/docs/source/examples/diffraction_objects_example.rst
@@ -180,7 +180,7 @@ For example, attempting to add a diffraction object and a string will raise an e
 
 .. code-block:: python
 
-    tth_ninety_index = diff_object1.get_array_index(90, xtype="tth")
+    tth_ninety_index = diff_object1.get_array_index(xtype="tth", xvalue=90)
     intensity_at_ninety = diff_object1.on_tth()[1][tth_ninety_index]
 
 If you do not specify an ``xtype``, it will default to the ``xtype`` used when creating the ``DiffractionObject``.

--- a/news/fix-example.rst
+++ b/news/fix-example.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Fix the example of using DiffractionObject.get_array_index in the documenattion.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address

Closes #352 

In the documentation, running the example code of `DiffractionObject.get_array_index` will throw an error.
This PR updates the example code of this function.

### What should the reviewer(s) do

Please check the updated documentation.