### PR TITLE
docs: fix the example of using `DiffractionObject.get_array_index` in the documentation

### DIFF
--- a/docs/source/examples/diffraction_objects_example.rst
+++ b/docs/source/examples/diffraction_objects_example.rst
@@ -180,7 +180,7 @@ For example, attempting to add a diffraction object and a string will raise an e
 
 .. code-block:: python
 
-    tth_ninety_index = diff_object1.get_array_index(90, xtype="tth")
+    tth_ninety_index = diff_object1.get_array_index(xvalue=90, xtype="tth")
     intensity_at_ninety = diff_object1.on_tth()[1][tth_ninety_index]
 
 If you do not specify an ``xtype``, it will default to the ``xtype`` used when creating the ``DiffractionObject``.
@@ -190,8 +190,8 @@ you can find its closest index for ``q=0.25`` by typing either of the following:
 .. code-block:: python
 
     print(do._input_xtype)     # remind ourselves which array was input.  prints "q" in this case.
-    index = do.get_array_index(0.25) # no xtype passed, defaults to do._input_xtype, or in this example, q
-    index = do.get_array_index(0.25, xtype="q") # explicitly choose an xtype to specify a value
+    index = do.get_array_index(xvalue=0.25) # no xtype passed, defaults to do._input_xtype, or in this example, q
+    index = do.get_array_index(xvalue=0.25, xtype="q") # explicitly choose an xtype to specify a value
 
 5. The ``dump`` function saves the diffraction data and relevant information to an xy format file with headers
 (widely used chi format used, for example, by Fit2D and diffpy.  These files can be read by ``LoadData()``

--- a/docs/source/examples/parsers_example.rst
+++ b/docs/source/examples/parsers_example.rst
@@ -104,8 +104,7 @@ Now we can extract specific data table columns from the dictionary.
 
      parsed_file_data = serialize_data('<PATH to data.txt>', hdata, data_table, serial_file='<PATH to serialfile.json>')
 
-   The returned value, ``parsed_file_data``, is the dictionary we just added to ``serialfile.json``.
-   To extract the data from the serial file, we use ``deserialize_data``.
+The returned value, ``parsed_file_data``, is the dictionary we just added to ``serialfile.json``. To extract the data from the serial file, we use ``deserialize_data``.
 
 .. code-block:: python
 

--- a/docs/source/examples/resample_example.rst
+++ b/docs/source/examples/resample_example.rst
@@ -33,18 +33,6 @@ To extract the columns, we can utilize the serialize function ...
      target_grid = nickel_data['Nickel.gr']['grid']
      target_func = nickel_data['Nickel.gr']['func']
 
-To extract the columns, we can utilize the serialize function ...
-
-.. code-block:: python
-
-     from diffpy.utils.parsers.serialization import serialize_data
-     nickel_data = serialize_data('Nickel.gr', {}, nickel_datatable, dt_colnames=['grid', 'func'])
-     nickel_grid = nickel_data['Nickel.gr']['grid']
-     nickel_func = nickel_data['Nickel.gr']['func']
-     target_data = serialize_data('NiTarget.gr', {}, nitarget_datatable, dt_colnames=['grid', 'function'])
-     target_grid = nickel_data['Nickel.gr']['grid']
-     target_func = nickel_data['Nickel.gr']['func']
-
 ... or you can use any other column extracting method you prefer.
 
 2) If we plot the two on top of each other

--- a/news/fix-docs-example.rst
+++ b/news/fix-docs-example.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* No news added: Fix the example of using ``DiffractionObject.get_array_index`` in the documentation.
+* No news added: Fix some examples in the documentation.
 
 **Changed:**
 

--- a/news/fix-docs-example.rst
+++ b/news/fix-docs-example.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Fix the example of using ``DiffractionObject.get_array_index`` in the documentation.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address

Fix the examples as mentioned in #352 
- [x] Failed example for `DiffractionObject.get_array_index`
- [x] Duplicate code block
- [ ] Failed example for `diffpy.utils.transform.d_to_tth`
- [x] Markup not rendered correctlly

Fix the documentation examples.

### What should reviewer(s) do

Please check the modified documentation.

example for `DiffractionObject.get_array_index`
<img width="1506" height="654" alt="image" src="https://github.com/user-attachments/assets/e3b1455b-4a7d-46c5-b32d-bd1d24235d77" />

Duplicate code block is removed
<img width="1479" height="557" alt="image" src="https://github.com/user-attachments/assets/3205fa72-a0c7-4588-9280-c06c1b8683ec" />

Markup is now rendered correctly
<img width="1455" height="587" alt="image" src="https://github.com/user-attachments/assets/cda6ca02-164f-4797-8acf-33894eb866c1" />
