### PR TITLE
Normalize paths before assert

### DIFF
--- a/news/headerfile.rst
+++ b/news/headerfile.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Normalize paths before assert in `test_serialization/test_load_multiple` to prevent possible Windows short/long name mismatch.
+
+**Security:**
+
+* <news item>

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -33,7 +33,9 @@ def test_load_multiple(tmp_path, datafile):
             dt_colnames=["r", "gr"],
             show_path=True,
         )
-        assert headerfile == Path(generated_data[headerfile.name].pop("path"))
+        assert Path(headerfile).resolve() == Path(
+            generated_data[headerfile.name].pop("path")
+        )
 
         # rerun without path information and save to file
         generated_data = serialize_data(


### PR DESCRIPTION
@sbillinge please check, thanks

Normalize paths before assert in `test_serialization/test_load_multiple` to prevent possible Windows short/long name mismatch.